### PR TITLE
Resolved #28

### DIFF
--- a/CoNVaDING.pl
+++ b/CoNVaDING.pl
@@ -2285,7 +2285,7 @@ sub countFromBam {
             $start=$array[1];
             $stop=$array[2];
             $gene=$array[3];
-            my $extractcov = "samtools depth -r $chr:$start-$stop -a -q 0 -Q 0 $bam | awk \'\{sum+=\$3\} END \{print sum\/NR\}\'";
+            my $extractcov = "samtools depth -r $chr:$start-$stop -a -a -q 0 -Q 0 $bam | awk \'\{sum+=\$3\} END \{print sum\/NR\}\'";
             $regioncov = `$extractcov`;
             chomp $regioncov;
             if (defined $regioncov and length $regioncov) { #Check for empty variable, if true set coverage to 0


### PR DESCRIPTION
I got the same error when the BAM file had zero coverage in al least one (but not all) regions described in the BED file.

I solved by editing the samtools command by providing an additional "-a" option

my $extractcov = "samtools depth -r $chr:$start-$stop -a -a -q 0 -Q 0 $bam | awk \'\{sum+=\$3\} END \{if (NR > 0) print sum\/NR; else print 0;\}\'";

(see the my edit "-a" after the first "-a")

In this way samtools produces the expected output with 0 coverage in every position.

Versions
- samtools v1.8 using htslib v1.8
- CoNVaDING 1.2.1